### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/lib/nats.go
+++ b/lib/nats.go
@@ -259,14 +259,16 @@ func isNoConnectivityErr(_ error) bool {
 func NewConnection(licenseID string, natscred NatsCredential) (nc *nats.Conn, err error) {
 	servers := natscred.Server
 
-	opts := []nats.Option{
+	opts := make([]nats.Option, 0, 6)
+	opts = append(
+		opts,
 		nats.Name(fmt.Sprintf("%s.%s", licenseID, info.ProductName)),
 		nats.MaxReconnects(-1),
 		nats.ErrorHandler(errorHandler),
 		nats.ReconnectHandler(reconnectHandler),
 		nats.DisconnectErrHandler(disconnectHandler),
 		// nats.UseOldRequestStyle(),
-	}
+	)
 
 	credFile := "/tmp/nats.creds"
 	if err = os.WriteFile(credFile, natscred.Credential, 0o600); err != nil {

--- a/lib/node.go
+++ b/lib/node.go
@@ -72,7 +72,8 @@ func (p *SiteInfoPublisher) OnUpdate(oldObj, newObj any) {
 	if alreadySentHourly &&
 		uOld.GetUID() == uNew.GetUID() && uOld.GetGeneration() == uNew.GetGeneration() {
 		if klog.V(8).Enabled() {
-			klog.V(8).InfoS("skipping update event",
+			klog.V(8).InfoS(
+				"skipping update event",
 				"gvk", uNew.GetObjectKind().GroupVersionKind(),
 				"namespace", uNew.GetNamespace(),
 				"name", uNew.GetName(),

--- a/lib/resource.go
+++ b/lib/resource.go
@@ -86,7 +86,8 @@ func (p *ResourceEventPublisher) OnUpdate(oldObj, newObj any) {
 	if alreadySentHourly &&
 		uOld.GetUID() == uNew.GetUID() && uOld.GetGeneration() == uNew.GetGeneration() {
 		if klog.V(8).Enabled() {
-			klog.V(8).InfoS("skipping update event",
+			klog.V(8).InfoS(
+				"skipping update event",
 				"gvk", uNew.GetObjectKind().GroupVersionKind(),
 				"namespace", uNew.GetNamespace(),
 				"name", uNew.GetName(),


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.

### Resulting fixes
- Preallocate slices flagged by the newly-enabled `prealloc` linter (capacity hints from the ranges being appended). No behavioral change.
