### PR TITLE
Fix NATS connection for IP-addressed and path-based event receivers

### DIFF
--- a/lib/nats.go
+++ b/lib/nats.go
@@ -18,9 +18,12 @@ package lib
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -255,11 +258,49 @@ func isNoConnectivityErr(_ error) bool {
 	return false
 }
 
+// normalizeServers defaults the port of each server in the comma separated
+// list to 443 when none is given, reports whether any of them is addressed by
+// a bare IP instead of a hostname, and returns the URL path, if any. The
+// websocket handshake builds its request from the host plus Options.ProxyPath
+// and drops the path of the server URL, so the path has to be handed back
+// separately and passed as nats.ProxyPath.
+func normalizeServers(servers string) (normalized string, isIP bool, proxyPath string) {
+	var out []string
+	for s := range strings.SplitSeq(servers, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		toParse := s
+		if !strings.Contains(toParse, "://") {
+			toParse = "nats://" + toParse
+		}
+		u, err := url.Parse(toParse)
+		if err != nil {
+			klog.V(5).InfoS("failed to parse event receiver address", "address", s, "error", err)
+			out = append(out, s)
+			continue
+		}
+		if net.ParseIP(u.Hostname()) != nil {
+			isIP = true
+		}
+		if path := strings.TrimSuffix(u.Path, "/"); path != "" && proxyPath == "" {
+			proxyPath = path
+		}
+		if u.Port() == "" {
+			u.Host = net.JoinHostPort(u.Hostname(), "443")
+		}
+		u.Path, u.RawQuery, u.Fragment = "", "", ""
+		out = append(out, u.String())
+	}
+	return strings.Join(out, ","), isIP, proxyPath
+}
+
 // NewConnection creates a new NATS connection
 func NewConnection(licenseID string, natscred NatsCredential) (nc *nats.Conn, err error) {
-	servers := natscred.Server
+	servers, ipHost, proxyPath := normalizeServers(natscred.Server)
 
-	opts := make([]nats.Option, 0, 6)
+	opts := make([]nats.Option, 0, 8)
 	opts = append(
 		opts,
 		nats.Name(fmt.Sprintf("%s.%s", licenseID, info.ProductName)),
@@ -269,6 +310,23 @@ func NewConnection(licenseID string, natscred NatsCredential) (nc *nats.Conn, er
 		nats.DisconnectErrHandler(disconnectHandler),
 		// nats.UseOldRequestStyle(),
 	)
+
+	if proxyPath != "" {
+		opts = append(opts, nats.ProxyPath(proxyPath))
+	}
+
+	// A bare IP address can't be matched against the serving cert's SANs, so
+	// hostname verification would always fail. Only the TLSConfig is set here,
+	// not nats.Secure(), so a non-TLS server still connects in plain mode.
+	if ipHost {
+		opts = append(opts, func(o *nats.Options) error {
+			if o.TLSConfig == nil {
+				o.TLSConfig = &tls.Config{} // nolint:gosec
+			}
+			o.TLSConfig.InsecureSkipVerify = true // nolint:gosec
+			return nil
+		})
+	}
 
 	credFile := "/tmp/nats.creds"
 	if err = os.WriteFile(credFile, natscred.Credential, 0o600); err != nil {
@@ -290,6 +348,7 @@ func NewConnection(licenseID string, natscred NatsCredential) (nc *nats.Conn, er
 	defer cancel()
 
 	ticker := time.NewTicker(natsConnectionRetryInterval)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
The websocket handshake in `nats.go` builds its request URL from the host plus `Options.ProxyPath` and drops the path of the server URL ([ws.go#L617-L625](https://github.com/nats-io/nats.go/blob/main/ws.go)). So a receiver address like `wss://10.2.1.39:443/nats` requested `/` instead and failed with:

```
invalid websocket connection
```

`NewConnection` now normalizes the receiver address before connecting:

- the URL path is stripped from the server list and passed as `nats.ProxyPath`, so the upgrade request hits `/nats`
- a missing port defaults to `443`
- when the receiver is addressed by a bare IP, TLS hostname verification is skipped — an IP can never match the serving cert SANs. Only `TLSConfig` is set, not `nats.Secure()`, so a non-TLS server still connects in plain mode.

Also stops the retry ticker on return; it leaked on every `NewConnection` call.